### PR TITLE
BUILD_FOR_WEB_DEPLOYMENT, dockerized image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 
 if(BUILD_FOR_WEB_DEPLOYMENT)
-    set(TRY_TO_STATIC_LINK ON)
+    set(TRY_TO_STATIC_LINK OFF)
     set(CMAKE_BUILD_TYPE:STRING "Release")
     set(USE_DB_TO_STORE_SPECTRA ON)
     #    set( USE_SQLITE3_DB ON )
@@ -182,7 +182,11 @@ if(BUILD_FOR_WEB_DEPLOYMENT)
     set(PERFORM_DEVELOPER_CHECKS OFF CACHE INTERNAL "")
     set(SpecUtils_ENABLE_EQUALITY_CHECKS OFF CACHE INTERNAL "")
     set(USE_SPECRUM_FILE_QUERY_WIDGET OFF)
-    set(USE_TERMINAL_WIDGET OFF)
+     # Default is OFF for web builds, but let the caller override with
+     # -DUSE_TERMINAL_WIDGET=ON
+    if(NOT DEFINED USE_TERMINAL_WIDGET OR (NOT USE_TERMINAL_WIDGET))
+        set(USE_TERMINAL_WIDGET OFF)       # keep old default
+    endif()
 endif(BUILD_FOR_WEB_DEPLOYMENT)
 
 if(BUILD_AS_LOCAL_SERVER)
@@ -436,7 +440,6 @@ set(headers
     InterSpec/UserPreferences.h
 )
 
-
 if(USE_DB_TO_STORE_SPECTRA)
     list(APPEND sources src/DbFileBrowser.cpp)
     list(APPEND headers InterSpec/DbFileBrowser.h)
@@ -619,17 +622,32 @@ add_subdirectory(external_libs/muparserx-4.0.7)
 
 add_library(InterSpecLib ${INTERSPEC_LIB_TYPE} ${sources} ${headers})
 
-
 # If we are the top-level project, we'll build the local-server exe
 if( NOT hasParent)
   add_executable(InterSpecExe main.cpp)
   target_link_libraries(InterSpecExe PUBLIC InterSpecLib)
   set_target_properties(InterSpecExe PROPERTIES OUTPUT_NAME "InterSpec")
+  # Tell the runtime linker to search ../lib beside the executable
+  if(UNIX AND NOT APPLE)           # $ORIGIN is a Linux/BSD feature
+    set_target_properties(InterSpecExe PROPERTIES
+        BUILD_RPATH  "$ORIGIN/../lib"
+        INSTALL_RPATH "$ORIGIN/../lib")
+    # makes variables such as $ORIGIN legal in BUILD_RPATH
+    set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+  endif()
 endif()
 
 
 set_target_properties(InterSpecLib PROPERTIES PREFIX "")
 set_target_properties(InterSpecLib PROPERTIES OUTPUT_NAME "InterSpec")
+
+if(UNIX AND NOT APPLE)           # $ORIGIN is a Linux/BSD feature
+  set_target_properties(InterSpecExe PROPERTIES
+      BUILD_RPATH  "$ORIGIN/../lib"
+      INSTALL_RPATH "$ORIGIN/../lib")
+  # makes variables such as $ORIGIN legal in BUILD_RPATH
+  set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+endif()
 
 # Turn off some compiler warnings
 target_compile_options(InterSpecLib PRIVATE
@@ -895,6 +913,14 @@ if( WIN32 )
   target_link_libraries( InterSpecLib PUBLIC opengl32.lib d2d1.lib windowscodecs.lib Dwrite.lib )
 endif( WIN32 )
 
+# after the target_link_libraries() for InterSpecLib / InterSpecExe
+if (CMAKE_CXX_STANDARD LESS 17)
+    # GCC < 9 still needs libstdc++fs for <experimental/filesystem>
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(InterSpecLib PUBLIC stdc++fs)
+    endif()
+endif()
+
 #if( ${PERFORM_DEVELOPER_CHECKS} EQUAL ${SpecUtils_ENABLE_EQUALITY_CHECKS} )
 #  MESSAGE(FATAL_ERROR "PERFORM_DEVELOPER_CHECKS (${PERFORM_DEVELOPER_CHECKS}) must be equal to SpecUtils_ENABLE_EQUALITY_CHECKS (${SpecUtils_ENABLE_EQUALITY_CHECKS})")
 #endif()
@@ -955,6 +981,9 @@ if(NOT WT_RESOURCES_DIRECTORY)
 else(NOT WT_RESOURCES_DIRECTORY)
     MESSAGE("Using Wt resources from ${WT_RESOURCES_DIRECTORY}")
     file(COPY ${WT_RESOURCES_DIRECTORY} DESTINATION ${PROJECT_BINARY_DIR}/)
+    if(BUILD_FOR_WEB_DEPLOYMENT)
+      file(COPY ${WT_RESOURCES_DIRECTORY} DESTINATION ${PROJECT_BINARY_DIR}/resources)
+    endif(BUILD_FOR_WEB_DEPLOYMENT)
 endif(NOT WT_RESOURCES_DIRECTORY)
 
 if(NOT ANDROID)
@@ -997,5 +1026,12 @@ configure_file(
 if( NOT hasParent )
   INSTALL(TARGETS InterSpecExe DESTINATION bin)
   INSTALL(TARGETS InterSpecLib DESTINATION lib)
-  INSTALL(DIRECTORY data example_spectra InterSpec_resources DESTINATION share/interspec)
+  install(DIRECTORY ${WT_RESOURCES_DIRECTORY}/
+        DESTINATION share/interspec/resources)
+  if( NOT BUILD_FOR_WEB_DEPLOYMENT)
+    INSTALL(DIRECTORY data example_spectra InterSpec_resources DESTINATION share/interspec)
+  else(NOT BUILD_FOR_WEB_DEPLOYMENT)
+    INSTALL(DIRECTORY example_spectra InterSpec_resources DESTINATION share/interspec)
+    INSTALL(DIRECTORY data DESTINATION share/interspec)
+  endif( NOT BUILD_FOR_WEB_DEPLOYMENT)
 endif( NOT hasParent )

--- a/InterSpec/InterSpec.h
+++ b/InterSpec/InterSpec.h
@@ -196,7 +196,7 @@ public:
   /** Returns if the staticDataDirectory has been explicitly set. */
   static InterSpec_API bool haveSetStaticDataDirectory();
   
-#if( BUILD_AS_ELECTRON_APP || IOS || ANDROID || BUILD_AS_OSX_APP || BUILD_AS_LOCAL_SERVER || BUILD_AS_WX_WIDGETS_APP || BUILD_AS_UNIT_TEST_SUITE )
+#if( BUILD_AS_ELECTRON_APP || IOS || ANDROID || BUILD_AS_OSX_APP || BUILD_AS_LOCAL_SERVER || BUILD_AS_WX_WIDGETS_APP || BUILD_AS_UNIT_TEST_SUITE || BUILD_FOR_WEB_DEPLOYMENT)
   /** Sets the directory were we can write write the user preference database
    file (if using sqlite3); also the location will search for extra detector
    response functions.

--- a/InterSpec/InterSpecServer.h
+++ b/InterSpec/InterSpecServer.h
@@ -59,9 +59,9 @@ namespace InterSpecServer
   InterSpec_API void startWebServer( std::string proccessname,
                              std::string basedir,
                              const std::string configpath,
-                             unsigned short int server_port_num = 0
+                             unsigned short int server_port_num
 #if( BUILD_FOR_WEB_DEPLOYMENT )
-                             , std::string http_address = "127.0.0.1"
+                             , std::string http_address
 #endif
                               );
   
@@ -91,9 +91,9 @@ namespace InterSpecServer
    */
   InterSpec_API int start_server( const char *process_name, const char *userdatadir,
                     const char *basedir, const char *xml_config_path,
-                    unsigned short int server_port_num = 0
+                    unsigned short int server_port_num
 #if( BUILD_FOR_WEB_DEPLOYMENT )
-                    , const char *http_address = "127.0.0.1"
+                    , const char *http_address
 #endif
                    );
   

--- a/main.cpp
+++ b/main.cpp
@@ -156,20 +156,20 @@ int main( int argc, char **argv )
   
   
 #if( BUILD_FOR_WEB_DEPLOYMENT )
-  if( cl_vm.count("config") )
+  if( !cl_vm.count("config") )
   {
     std::cerr << "You must specify the Wt config file to use (the 'config' option)" << std::endl;
     return -20;
   }
   
-  if( cl_vm.count("http-address") )
+  if( !cl_vm.count("http-address") )
   {
     std::cerr << "You must specify the network adapter address to bind to"
     << " (the 'http-address' option)." << std::endl;
     return -21;
   }
   
-  if( cl_vm.count("docroot") )
+  if( !cl_vm.count("docroot") )
   {
     std::cerr << "You must specify the HTTP document root directory to use (the 'docroot' option)" << std::endl;
     return -22;
@@ -301,7 +301,11 @@ int main( int argc, char **argv )
   const int rval = InterSpecServer::start_server( argv[0], user_data_dir.c_str(),
                                                  docroot.c_str(),
                                                  wt_config.c_str(),
-                                                 static_cast<short int>(server_port_num) );
+                                                 static_cast<short int>(server_port_num)
+#if( BUILD_FOR_WEB_DEPLOYMENT )
+                                                 , http_address.c_str()
+#endif
+                                                 );
   if( rval < 0 )
   {
     std::cerr << "Failed to start server, val=" << rval << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -163,6 +163,7 @@ int main( int argc, char **argv )
   }
   
   if( !cl_vm.count("http-address") )
+  if( !cl_vm.count("http-address") )
   {
     std::cerr << "You must specify the network adapter address to bind to"
     << " (the 'http-address' option)." << std::endl;
@@ -171,8 +172,21 @@ int main( int argc, char **argv )
   
   if( !cl_vm.count("docroot") )
   {
-    std::cerr << "You must specify the HTTP document root directory to use (the 'docroot' option)" << std::endl;
-    return -22;
+      // directory that holds the executable
+      std::string exe_dir = SpecUtils::parent_path(argv[0]);
+      // …/share/interspec
+      docroot = SpecUtils::append_path(
+                    SpecUtils::append_path(SpecUtils::append_path(exe_dir, ".."),
++                                           "share"),
++                    "interspec");
+      SpecUtils::make_canonical_path(docroot);   // collapse .. / .
+
+      if (!SpecUtils::is_directory(docroot))
+      {
+          std::cerr << "Unable to locate default docroot at '" << docroot
+                    << "'.  Please supply the '--docroot' option.\n";
+          return -22;
+      }
   }
 #endif
   
@@ -241,7 +255,7 @@ int main( int argc, char **argv )
     }//if( !SpecUtils::is_absolute_path(userDir) )
     
     user_data_dir = dev_user_data;
-#else
+#elseif( !BUILD_FOR_WEB_DEPLOYMENT )
     std::cerr << "You must specify the directory to store user data to (the 'userdatadir' option)."
               << std::endl;
     return -25;
@@ -279,6 +293,17 @@ int main( int argc, char **argv )
 #if( !BUILD_FOR_WEB_DEPLOYMENT )
   else
   {
+    const std::string datadir = SpecUtils::append_path( docroot, "data" );
+    if( !SpecUtils::is_directory(datadir) )
+    {
+      std::cerr << "No 'data' directory in docroot-'" << docroot << "';"
+                << " please specify the '--static-data-dir' argument." << std::endl;
+      return -26;
+    }
+    InterSpec::setStaticDataDirectory( datadir );
+  }//if( cl_vm.count("static-data-dir") ) / else
+#else
+    {
     const std::string datadir = SpecUtils::append_path( docroot, "data" );
     if( !SpecUtils::is_directory(datadir) )
     {

--- a/src/InterSpec.cpp
+++ b/src/InterSpec.cpp
@@ -64,6 +64,7 @@
 #include <Wt/WSuggestionPopup>
 #include <Wt/WContainerWidget>
 #include <Wt/WDefaultLoadingIndicator>
+#include <Wt/WEvent>
 
 #if( USE_CSS_FLEX_LAYOUT )
 #include <Wt/WStackedWidget>
@@ -704,13 +705,37 @@ InterSpec::InterSpec( WContainerWidget *parent )
     m_mobileBackButton = new WContainerWidget( wApp->domRoot() );
     m_mobileBackButton->addStyleClass( "MobilePrevSample btn" );
     m_mobileBackButton->setZIndex( 8388635 );
-    m_mobileBackButton->clicked().connect( boost::bind(&InterSpec::handleUserIncrementSampleNum, this, SpecUtils::SpectrumType::Foreground, false) );
+    /* mobile “back” button */
+    // OLD (fails – functor takes 0 args but signal provides 1):
+    // m_mobileBackButton->clicked().connect(
+    //     boost::bind(&InterSpec::handleUserIncrementSampleNum,
+    //                 this, SpecUtils::SpectrumType::Foreground, false) );
+
+    // NEW
+    m_mobileBackButton->clicked().connect(
+         [this](const Wt::WMouseEvent &)     // ignore the event
+         {
+           handleUserIncrementSampleNum(SpecUtils::SpectrumType::Foreground,
+                                        false);
+         });
     m_mobileBackButton->setHidden(true);
       
     m_mobileForwardButton = new WContainerWidget( wApp->domRoot() );
     m_mobileForwardButton->addStyleClass( "MobileNextSample btn" );
     m_mobileForwardButton->setZIndex( 8388635 );
-    m_mobileForwardButton->clicked().connect( boost::bind(&InterSpec::handleUserIncrementSampleNum, this, SpecUtils::SpectrumType::Foreground, true) );
+    /* mobile “forward” button */
+    // OLD
+    // m_mobileForwardButton->clicked().connect(
+    //     boost::bind(&InterSpec::handleUserIncrementSampleNum,
+    //                 this, SpecUtils::SpectrumType::Foreground, true) );
+
+    // NEW
+    m_mobileForwardButton->clicked().connect(
+        [this](const Wt::WMouseEvent &)
+        {
+          handleUserIncrementSampleNum(SpecUtils::SpectrumType::Foreground,
+                                      true);
+        });
     m_mobileForwardButton->setHidden(true);
   }else  //if( isMobile() )
   {

--- a/src/InterSpec.cpp
+++ b/src/InterSpec.cpp
@@ -1581,8 +1581,10 @@ void InterSpec::layoutSizeChanged( int w, int h )
         if( m_enterUri )
           m_enterUri->accept();
         assert( !m_enterUri );
+#if( USE_TERMINAL_WIDGET )
         if( m_terminalWindow )
           m_terminalWindow->hide();
+#endif
 #if( USE_REMOTE_RID )
         if( m_remoteRidWindow )
           deleteRemoteRidWindow();
@@ -10065,7 +10067,7 @@ void InterSpec::addToolsMenu( Wt::WWidget *parent )
   extRidTT.arg( "" );
 #endif
   
-  HelpSystem::attachToolTipOn( m_terminalMenuItem, extRidTT, showToolTips );
+  HelpSystem::attachToolTipOn( m_remoteRidMenuItem, extRidTT, showToolTips );
   m_remoteRidMenuItem->triggered().connect( this, &InterSpec::createRemoteRidWindow );
 #endif
 }//void InterSpec::addToolsMenu( Wt::WContainerWidget *menuDiv )

--- a/src/InterSpecServer.cpp
+++ b/src/InterSpecServer.cpp
@@ -566,9 +566,17 @@ int start_server( const char *process_name,
     //  cerr << "Unable to change to directory: '" << basedir << "' :" << e.what() << endl;
     //}
 
+#if( BUILD_FOR_WEB_DEPLOYMENT )
+  const string server_http_address = http_address ? http_address : "127.0.0.1";
+#endif
+
   try
   {
-    InterSpecServer::startWebServer( process_name, relbasedir, wt_config_file, server_port );
+    InterSpecServer::startWebServer( process_name, relbasedir, wt_config_file, server_port
+#if( BUILD_FOR_WEB_DEPLOYMENT )
+                             , server_http_address
+#endif
+                                    );
   }catch( std::exception &e )
   {
     std::cerr << "\n\nCaught exception trying to start InterSpec server:\n\t"

--- a/src/InterSpecServer.cpp
+++ b/src/InterSpecServer.cpp
@@ -447,7 +447,7 @@ int start_server( const char *process_name,
   {
     //ToDo: refactor this userdatadir stuff into function inside InterSpecServer
     //      or InterSpecApp or something.
-    if( !SpecUtils::create_directory(userdatadir) )
+    if( !SpecUtils::create_directory(userdatadir) && !BUILD_FOR_WEB_DEPLOYMENT)
       throw std::runtime_error( "Failed to create directory '" + string(userdatadir) + "' for user data." );
   }catch( std::exception &e )
   {

--- a/src/InterSpecWritableDir.cpp
+++ b/src/InterSpecWritableDir.cpp
@@ -1,0 +1,31 @@
+#include "InterSpec/InterSpec.h"
+#include <stdexcept>
+
+#if ( BUILD_AS_ELECTRON_APP || IOS || ANDROID || BUILD_AS_OSX_APP || \
+      BUILD_AS_LOCAL_SERVER || BUILD_AS_WX_WIDGETS_APP ||            \
+      BUILD_AS_UNIT_TEST_SUITE || BUILD_FOR_WEB_DEPLOYMENT )
+
+namespace           // anonymous – internal linkage
+{
+    std::string &dir()
+    {
+        static std::string writableDir;   // held for the life of the process
+        return writableDir;
+    }
+}
+
+void InterSpec::setWritableDataDirectory(const std::string &d)
+{
+    if (d.empty())
+        throw std::invalid_argument("Writable data directory may not be empty");
+    dir() = d;
+}
+
+std::string InterSpec::writableDataDirectory()
+{
+    if (dir().empty())
+        throw std::runtime_error("Writable data directory has not been set");
+    return dir();
+}
+
+#endif // build‑flag block

--- a/src/IsotopeSearchByEnergy.cpp
+++ b/src/IsotopeSearchByEnergy.cpp
@@ -1158,7 +1158,8 @@ void IsotopeSearchByEnergy::init_category_info( std::vector<NucSearchCategory> &
   
   if( append_categories(def_xml) <= 0 )
     throw runtime_error( "Failed to load default NuclideSearchCatagories.xml" );
-  
+
+#if( !BUILD_FOR_WEB_DEPLOYMENT )
   // Load user specific category info
   const string user_data_dir = InterSpec::writableDataDirectory();
   const std::string user_xml = SpecUtils::append_path(def_xml, "NuclideSearchCatagories.xml");
@@ -1167,6 +1168,7 @@ void IsotopeSearchByEnergy::init_category_info( std::vector<NucSearchCategory> &
     if( SpecUtils::is_file(user_xml) )
       throw runtime_error( "Error loading user NuclideSearchCatagories.xml" );
   }
+#endif
 }//static void init_category_info( std::vector<NucSearchCategory> &results );
 
 

--- a/target/docker/alpine_web_container.dockerfile
+++ b/target/docker/alpine_web_container.dockerfile
@@ -1,10 +1,59 @@
+FROM alpine:latest AS build
+WORKDIR /work
+ARG  tag=master
+ARG  repo=https://github.com/JStrader-Mirion/InterSpec.git
+# RUN statements are broken up to allow loading cached images for debugging
+RUN  apk add --no-cache \
+     alpine-sdk \
+     cmake \
+     patch \
+     linux-headers \
+     suitesparse-dev patch \
+     curl \
+     uglify-js \
+     uglifycss \
+     git && \
+     git clone --recursive --depth 1 --branch ${tag} ${repo} ./src
+RUN  cmake \
+        -B ./build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_FOR_WEB_DEPLOYMENT=ON \
+        -DUSE_REL_ACT_TOOL=ON \
+        -DBUILD_AS_LOCAL_SERVER=OFF \
+        -DInterSpec_FETCH_DEPENDENCIES=ON \
+        -DBoost_INCLUDE_DIR=./build/_deps/boost-src/libs \
+        -DUSE_SEARCH_MODE_3D_CHART=ON \
+        -DUSE_QR_CODES=ON \
+        -DUSE_DETECTION_LIMIT_TOOL=ON \
+        -DUSE_SPECRUM_FILE_QUERY_WIDGET=ON \
+        -DSpecUtils_PYTHON_BINDINGS=ON  \
+        ./src
+RUN  mkdir -p /InterSpec && \
+     cmake --build build -j4
+RUN  cmake --install ./build --prefix ./InterSpec && \
+        rm -rf ./InterSpec/lib/cmake
+
+#Web Server
 FROM alpine:latest
-
-WORKDIR /mnt/host
-
-SHELL ["/bin/sh", "-c"]
-
+LABEL app="InterSpec"
+COPY --from=build /work/InterSpec /interspec/
+WORKDIR /interspec
 EXPOSE 8078
+RUN apk --no-cache add \
+        openblas \
+        libstdc++ \
+        libgcc && \
+        chmod -R a+r * && \
+        chmod a+x bin/InterSpec &&  \
+        chmod 777 /interspec && \
+        mkdir /data && \
+        chmod 777 /data
+SHELL ["/bin/sh", "-c"]
+ENTRYPOINT ["./bin/InterSpec", "-c ./share/interspec/data/config/wt_config_web.xml", "--userdatadir=/data", "--http-port=8078", "--http-address=0.0.0.0"]
+
+#Build: docker build -t interspec -f alpine_web_container.dockerfile .
+#Run, linux host: docker run --rm -v "$PWD":/data -p 8078:8078/tcp interspec
+#Run, windows host: docker run --rm -v `pwd`:/data -p 8078:8078/tcp interspec
 
 # Then numeric group/user value of 280 was chosen randomly; it doesnt conflict with existing groups/users on dev or public server, and is below 1000 (e.g., a system user without a home directory or default shell)
 #RUN groupadd --gid 280 interspec && useradd --uid 280 --gid interspec interspec
@@ -13,24 +62,8 @@ EXPOSE 8078
 # Or just use user guest
 #USER guest
 
-# Copy our app into the container
-# --chown=fullspec:fullspec
-COPY build_alpine/interspec_install /var/opt/interspec
-RUN chmod -R a+r /var/opt/interspec \
-     && chmod a+x /var/opt/interspec/InterSpec \
-     && chmod -R uga-w /var/opt/interspec
-
-USER guest
-
-WORKDIR /var/opt/interspec
-
-# You could keep the access log by chenging the entrypoint to: "--accesslog=/mnt/interspec_data/wt_access_log.txt"
-# You could also edit the <log-file></log-file> element of data/config/wt_config_web.xml to save the stdout/stderr of InterSpec to a log file at /mnt/interspec_data/interspec_log.txt.
-
-ENTRYPOINT ["/var/opt/interspec/InterSpec", "--docroot=/var/opt/interspec/html_root/", "--http-address=0.0.0.0", "--http-port=8078", "--config=/var/opt/interspec/html_root/data/config/wt_config_web.xml", "--userdatadir", "/mnt/interspec_data/", "--static-data-dir", "/var/opt/interspec/html_root/data/"]
-#ENTRYPOINT ["/var/opt/interspec/InterSpec", "--docroot=/var/opt/interspec/html_root/", "--http-address=0.0.0.0", "--http-port=8078", "--config=/var/opt/interspec/html_root/data/config/wt_config_web.xml", "--userdatadir /var/opt/interspec/", "--static-data-dir", "/var/opt/interspec/html_root/data/"]
-
-
 # If build fails, issue this command
 # docker rmi $(docker images -f “dangling=true” -q)
 # docker system prune
+# You could keep the access log by chenging the entrypoint to: "--accesslog=/mnt/interspec_data/wt_access_log.txt"
+# You could also edit the <log-file></log-file> element of data/config/wt_config_web.xml to save the stdout/stderr of InterSpec to a log file at /mnt/interspec_data/interspec_log.txt.

--- a/target/patches/SpecUtils/SpecUtils_ForceDynamic.patch
+++ b/target/patches/SpecUtils/SpecUtils_ForceDynamic.patch
@@ -1,0 +1,27 @@
+From ebb7b7c796061c75cc93db0ba1d117197e7abf03 Mon Sep 17 00:00:00 2001
+From: JStrader-Mirion <jstrader@mirion.com>
+Date: Mon, 21 Apr 2025 02:47:31 -0400
+Subject: [PATCH] Force dynamic linking
+
+---
+ CMakeLists.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -422,3 +422,10 @@ configure_file(
+ )
+ 
+ 
++# Ensure we link libm dynamically
++target_link_options(SpecUtils PRIVATE "-Wl,-Bdynamic" "-lm")
++# Remove accidental global -static
++string(REPLACE "-static" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
++if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++    add_compile_options(-Wno-unknown-warning-option)
++endif()
+\ No newline at end of file
+-- 
+2.39.5
+


### PR DESCRIPTION
All my attempts to compile with the BUILD_FOR_WEB_DEPLOYMENT flag in Linux have failed, and I believe that the current implementations are out of date. I have updated /target/docker/alpine_web_container.dockerfile, so that it now compiles and serves InterSpec. While this appears to work perfectly for my environment, it may need a few refinements to ensure it doesn't interfere with your more popular implementations.

One small change was needed to SpecUtils, and I have simply included a patch file (auto-applied in Docker) here before I open a PR against that repo. Note: the Dockerfile currently points to my fork of InterSpec and will need to be updated on merge.

